### PR TITLE
Not halting validation when returning false from model.beforeValidate

### DIFF
--- a/src/Database/Traits/Validation.php
+++ b/src/Database/Traits/Validation.php
@@ -181,7 +181,7 @@ trait Validation
          *     });
          *
          */
-        if (($this->fireModelEvent('validating') === false) || ($this->fireEvent('model.beforeValidate') === false)) {
+        if (($this->fireModelEvent('validating') === false) || ($this->fireEvent('model.beforeValidate', [], true) === false)) {
             if ($throwOnValidation) {
                 throw new ModelException($this);
             }


### PR DESCRIPTION
Call to `fireEvent` returns an array so will never equal `false`. Setting halt parameter to `true` fixes this.